### PR TITLE
New number formatting options j-brooke/FracturedJsonJs#10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 obj
 **/*.user
+FracturedJsonCli/scratch

--- a/FracturedJson/Formatter.cs
+++ b/FracturedJson/Formatter.cs
@@ -280,7 +280,7 @@ public class Formatter
             return false;
 
         // If all items are alike, we'll want to format each element as if it were a table row.
-        var template = new TableTemplate(_pads, !Options.DontJustifyNumbers);
+        var template = new TableTemplate(_pads, Options.NumberListAlignment);
         template.MeasureTableRoot(item);
 
         // If we can't fit lots of them on a line, compact multiline isn't a good choice.  Table would likely
@@ -353,7 +353,7 @@ public class Formatter
 
         // Create a helper object to measure how much space we'll need.  If this item's children aren't sufficiently
         // similar, IsRowDataCompatible will be false.
-        var template = new TableTemplate(_pads, !Options.DontJustifyNumbers);
+        var template = new TableTemplate(_pads, Options.NumberListAlignment);
         template.MeasureTableRoot(item);
         if (!template.IsRowDataCompatible)
             return false;
@@ -602,9 +602,10 @@ public class Formatter
             else
                 InlineTableRawObject(template, item);
         }
-        else if (template.IsFormattableNumber && item.Type != JsonItemType.Null)
+        else if (template.IsNumberList)
         {
-            _buffer.Add(template.FormatNumber(item.Value));
+            var (leftPad, valStr, rightPad) = template.FormatNumber(item);
+            _buffer.Add(_pads.Spaces(leftPad), valStr, _pads.Spaces(rightPad));
         }
         else
         {

--- a/FracturedJson/Formatter.cs
+++ b/FracturedJson/Formatter.cs
@@ -604,8 +604,7 @@ public class Formatter
         }
         else if (template.IsNumberList)
         {
-            var (leftPad, valStr, rightPad) = template.FormatNumber(item);
-            _buffer.Add(_pads.Spaces(leftPad), valStr, _pads.Spaces(rightPad));
+            template.FormatNumber(_buffer, item);
         }
         else
         {

--- a/FracturedJson/Formatter.cs
+++ b/FracturedJson/Formatter.cs
@@ -156,8 +156,15 @@ public class Formatter
         foreach(var child in item.Children)
             ComputeItemLengths(child);
 
+        item.ValueLength = item.Type switch
+        {
+            JsonItemType.Null => _pads.LiteralNullLen,
+            JsonItemType.True => _pads.LiteralTrueLen,
+            JsonItemType.False => _pads.LiteralFalseLen,
+            _ => StringLengthFunc(item.Value)
+        };
+
         item.NameLength = StringLengthFunc(item.Name);
-        item.ValueLength = StringLengthFunc(item.Value);
         item.PrefixCommentLength = StringLengthFunc(item.PrefixComment);
         item.MiddleCommentLength = StringLengthFunc(item.MiddleComment);
         item.PostfixCommentLength = StringLengthFunc(item.PostfixComment);

--- a/FracturedJson/Formatting/PaddedFormattingTokens.cs
+++ b/FracturedJson/Formatting/PaddedFormattingTokens.cs
@@ -13,6 +13,9 @@ internal class PaddedFormattingTokens
     public int CommaLen { get; }
     public int ColonLen { get; }
     public int CommentLen { get; }
+    public int LiteralNullLen { get; }
+    public int LiteralTrueLen { get; }
+    public int LiteralFalseLen { get; }
     public int PrefixStringLen { get; }
     public string DummyComma => Spaces(CommaLen);
     
@@ -63,6 +66,9 @@ internal class PaddedFormattingTokens
         CommaLen = strLenFunc(Comma);
         ColonLen = strLenFunc(Colon);
         CommentLen = strLenFunc(Comment);
+        LiteralNullLen = strLenFunc("null");
+        LiteralTrueLen = strLenFunc("true");
+        LiteralFalseLen = strLenFunc("false");
         PrefixStringLen = strLenFunc(opts.PrefixString);
     }
 

--- a/FracturedJson/Formatting/TableTemplate.cs
+++ b/FracturedJson/Formatting/TableTemplate.cs
@@ -219,8 +219,8 @@ internal class TableTemplate
         }
         else if (rowSegment.Type is JsonItemType.Null)
         {
-            _maxDigBeforeDecNorm = Math.Max(_maxDigBeforeDecNorm, 4);
-            _maxDigBeforeDecRaw = Math.Max(_maxDigBeforeDecRaw, 4);
+            _maxDigBeforeDecNorm = Math.Max(_maxDigBeforeDecNorm, _pads.LiteralNullLen);
+            _maxDigBeforeDecRaw = Math.Max(_maxDigBeforeDecRaw, _pads.LiteralNullLen);
         }
         else
         {
@@ -370,16 +370,17 @@ internal class TableTemplate
 
     private int GetNumberFieldWidth()
     {
-        switch (_numberListAlignment)
+        if (_numberListAlignment == NumberListAlignment.Normalize && AllowNumberNormalization)
         {
-            case NumberListAlignment.Decimal:
-                var rawDecLen = (_maxDigAfterDecRaw > 0) ? 1 : 0;
-                return _maxDigBeforeDecRaw + rawDecLen + _maxDigAfterDecRaw;
-            case NumberListAlignment.Normalize:
-                var normDecLen = (_maxDigAfterDecNorm > 0) ? 1 : 0;
-                return _maxDigBeforeDecNorm + normDecLen + _maxDigAfterDecNorm;
-            default:
-                return SimpleValueLength;
+            var normDecLen = (_maxDigAfterDecNorm > 0) ? 1 : 0;
+            return _maxDigBeforeDecNorm + normDecLen + _maxDigAfterDecNorm;
         }
+        else if (_numberListAlignment == NumberListAlignment.Decimal)
+        {
+            var rawDecLen = (_maxDigAfterDecRaw > 0) ? 1 : 0;
+            return _maxDigBeforeDecRaw + rawDecLen + _maxDigAfterDecRaw;
+        }
+
+        return SimpleValueLength;
     }
 }

--- a/FracturedJson/FracturedJsonOptions.cs
+++ b/FracturedJson/FracturedJsonOptions.cs
@@ -110,6 +110,8 @@ public record FracturedJsonOptions
     /// </summary>
     public bool DontJustifyNumbers { get; set; } = false;
 
+    public NumberListAlignment NumberListAlignment { get; set; } = NumberListAlignment.Normalize;
+
     /// <summary>
     /// Number of spaces to use per indent level.  If <see cref="UseTabToIndent"/> is true, spaces won't be used but
     /// this number will still be used in length computations.

--- a/FracturedJson/FracturedJsonOptions.cs
+++ b/FracturedJson/FracturedJsonOptions.cs
@@ -104,12 +104,11 @@ public record FracturedJsonOptions
     /// line comments).
     /// </summary>
     public bool OmitTrailingWhitespace { get; set; } = false;
-    
-    /// <summary>
-    /// If true, numbers won't be right-aligned with matching precision.
-    /// </summary>
-    public bool DontJustifyNumbers { get; set; } = false;
 
+    /// <summary>
+    /// Controls how lists or columns of numbers (possibly with nulls) are aligned, and whether their precision
+    /// may be normalized.
+    /// </summary>
     public NumberListAlignment NumberListAlignment { get; set; } = NumberListAlignment.Normalize;
 
     /// <summary>

--- a/FracturedJson/NumberListAlignment.cs
+++ b/FracturedJson/NumberListAlignment.cs
@@ -1,9 +1,32 @@
 namespace FracturedJson;
 
+/// <summary>
+/// Options for how lists or columns of numbers should be aligned, and whether the precision may be changed
+/// to be consistent.
+/// </summary>
 public enum NumberListAlignment
 {
+    /// <summary>
+    /// Left-aligns numbers, keeping each exactly as it appears in the input document.
+    /// </summary>
     Left,
+
+    /// <summary>
+    /// Right-aligns numbers, keeping each exactly as it appears in the input document.
+    /// </summary>
     Right,
+
+    /// <summary>
+    /// Arranges the numbers so that the decimal points line up, but keeps each value exactly as it appears in the
+    /// input document.  Numbers expressed in scientific notation are aligned according to the significand's decimal
+    /// point, if any, or the "e".
+    /// </summary>
     Decimal,
+
+    /// <summary>
+    /// Tries to rewrite all numbers in the list in regular, non-scientific notation, all with the same number of digits
+    /// after the decimal point, all lined up.  If any of the numbers have too many digits or can't be written without
+    /// scientific notation, left-alignment is used as a fallback.
+    /// </summary>
     Normalize,
 }

--- a/FracturedJson/NumberListAlignment.cs
+++ b/FracturedJson/NumberListAlignment.cs
@@ -1,0 +1,9 @@
+namespace FracturedJson;
+
+public enum NumberListAlignment
+{
+    Left,
+    Right,
+    Decimal,
+    Normalize,
+}

--- a/FracturedJsonCli/.gitignore
+++ b/FracturedJsonCli/.gitignore
@@ -1,1 +1,0 @@
-scratch

--- a/FracturedJsonCli/Cli.cs
+++ b/FracturedJsonCli/Cli.cs
@@ -38,7 +38,17 @@ namespace FracturedJsonCli
                     { "e|expand=", "always-expand depth", (int n) => options.AlwaysExpandDepth = n },
                     { "f|file=", "input from file instead of stdin", s => fileName = s },
                     { "h|help", "show this help info and exit", _ => showHelp = true },
-                    { "j|no-justify", "don't justify parallel numbers", _ => options.DontJustifyNumbers = true },
+                    {
+                        "j|justify=", "number list justification [l,r,d,n]", s =>
+                            options.NumberListAlignment = s.ToUpper() switch
+                        {
+                            "L" or "LEFT" => NumberListAlignment.Left,
+                            "R" or "RIGHT" => NumberListAlignment.Right,
+                            "D" or "DECIMAL" => NumberListAlignment.Decimal,
+                            "N" or "NORMALIZE" => NumberListAlignment.Normalize,
+                            _ => NumberListAlignment.Left,
+                        }
+                    },
                     {
                         "l|length=",
                         "maximum total line length when inlining",

--- a/Tests/NumberFormattingTests.cs
+++ b/Tests/NumberFormattingTests.cs
@@ -139,6 +139,39 @@ public class NumberFormattingTests
     }
 
     [TestMethod]
+    public void AccurateCompositeLengthForNormalized()
+    {
+        // Make sure the the inner TableTemplate is accurately reporting the CompositeLength.  Otherwise,
+        // the null row won't have the right number of spaces.
+        var inputRows = new[]
+        {
+            "[",
+            "    { \"a\": {\"val\": 12345} },",
+            "    { \"a\": {\"val\": 6.78901} },",
+            "    { \"a\": null },",
+            "    { \"a\": {\"val\": 1e500} }",
+            "]",
+        };
+
+        var input = string.Join(string.Empty, inputRows);
+        var opts = new FracturedJsonOptions()
+        {
+            MaxTotalLineLength = 40,
+            JsonEolStyle = EolStyle.Lf,
+            OmitTrailingWhitespace = true,
+            NumberListAlignment = NumberListAlignment.Normalize
+        };
+
+        var formatter = new Formatter() { Options = opts };
+        var output = formatter.Reformat(input, 0);
+        var outputRows = output.TrimEnd().Split('\n');
+
+        Assert.AreEqual(6, outputRows.Length);
+        Assert.AreEqual(outputRows[2].Length, outputRows[3].Length);
+    }
+
+
+    [TestMethod]
     public void LeftAlignMatchesExpected()
     {
         var expectedRows = new[]
@@ -208,7 +241,6 @@ public class NumberFormattingTests
 
     private static void TestAlignment(NumberListAlignment align, string[] expectedRows)
     {
-
         var input = string.Join(string.Empty, _numberTable);
         var opts = new FracturedJsonOptions()
         {

--- a/Tests/NumberFormattingTests.cs
+++ b/Tests/NumberFormattingTests.cs
@@ -59,23 +59,6 @@ public class NumberFormattingTests
     }
 
     [TestMethod]
-    public void DontJustifyOptionRespected()
-    {
-        const string input = "[1, 2.1, 3, -99]";
-        const string expectedOutput = "[\n    1  , 2.1, 3  , -99\n]";
-
-        // Here, it's formatted as a compact multiline array (but not really multiline).  But since we're telling it
-        // not to justify numbers, they're treated like text: left-aligned and space-padded.
-        var opts = new FracturedJsonOptions()
-            { MaxInlineComplexity = -1, DontJustifyNumbers = true, JsonEolStyle = EolStyle.Lf };
-
-        var formatter = new Formatter() { Options = opts };
-        var output = formatter.Reformat(input, 0);
-
-        Assert.AreEqual(expectedOutput, output.TrimEnd());
-    }
-
-    [TestMethod]
     public void BigNumbersInvalidateAlignment1()
     {
         const string input = "[1, 2.1, 3, 1e+99]";
@@ -154,4 +137,103 @@ public class NumberFormattingTests
 
         Assert.AreEqual(expectedOutput, output.TrimEnd());
     }
+
+    [TestMethod]
+    public void LeftAlignMatchesExpected()
+    {
+        var expectedRows = new[]
+        {
+            "[",
+            "    [123.456 , 0      , 0   ],",
+            "    [234567.8, 0      , 0   ],",
+            "    [3       , 0.00000, 7e2 ],",
+            "    [null    , 2e-1   , 80e1],",
+            "    [5.6789  , 3.5e-1 , 0   ]",
+            "]",
+        };
+
+        TestAlignment(NumberListAlignment.Left, expectedRows);
+    }
+
+    [TestMethod]
+    public void RightAlignMatchesExpected()
+    {
+        var expectedRows = new[]
+        {
+            "[",
+            "    [ 123.456,       0,    0],",
+            "    [234567.8,       0,    0],",
+            "    [       3, 0.00000,  7e2],",
+            "    [    null,    2e-1, 80e1],",
+            "    [  5.6789,  3.5e-1,    0]",
+            "]",
+        };
+
+        TestAlignment(NumberListAlignment.Right, expectedRows);
+    }
+
+    [TestMethod]
+    public void DecimalAlignMatchesExpected()
+    {
+        var expectedRows = new[]
+        {
+            "[",
+            "    [   123.456 , 0      ,  0  ],",
+            "    [234567.8   , 0      ,  0  ],",
+            "    [     3     , 0.00000,  7e2],",
+            "    [  null     , 2e-1   , 80e1],",
+            "    [     5.6789, 3.5e-1 ,  0  ]",
+            "]",
+        };
+
+        TestAlignment(NumberListAlignment.Decimal, expectedRows);
+    }
+
+    [TestMethod]
+    public void NormalizeAlignMatchesExpected()
+    {
+        var expectedRows = new[]
+        {
+            "[",
+            "    [   123.4560, 0.00,   0],",
+            "    [234567.8000, 0.00,   0],",
+            "    [     3.0000, 0.00, 700],",
+            "    [  null     , 0.20, 800],",
+            "    [     5.6789, 0.35,   0]",
+            "]",
+        };
+
+        TestAlignment(NumberListAlignment.Normalize, expectedRows);
+    }
+
+    private static void TestAlignment(NumberListAlignment align, string[] expectedRows)
+    {
+
+        var input = string.Join(string.Empty, _numberTable);
+        var opts = new FracturedJsonOptions()
+        {
+            MaxTotalLineLength = 60,
+            JsonEolStyle = EolStyle.Lf,
+            OmitTrailingWhitespace = true,
+            NumberListAlignment = align
+        };
+
+        var formatter = new Formatter() { Options = opts };
+        var output = formatter.Reformat(input, 0);
+        var outputRows = output.TrimEnd().Split('\n');
+
+        CollectionAssert.AreEqual(expectedRows, outputRows);
+    }
+
+
+    private static readonly string[] _numberTable = new[]
+    {
+        "[",
+        "    [ 123.456, 0, 0 ],",
+        "    [ 234567.8, 0, 0 ],",
+        "    [ 3, 0.00000, 7e2 ],",
+        "    [ null, 2e-1, 80e1 ],",
+        "    [ 5.6789, 3.5e-1, 0 ]",
+        "]",
+    };
 }

--- a/Tests/UniversalJsonTests.cs
+++ b/Tests/UniversalJsonTests.cs
@@ -258,7 +258,7 @@ public class UniversalJsonTests
             AlwaysExpandDepth = int.MaxValue,
             CommentPolicy = CommentPolicy.Preserve,
             PreserveBlankLines = true,
-            DontJustifyNumbers = true,
+            NumberListAlignment = NumberListAlignment.Decimal,
         };
         var expandFormatter = new Formatter() { Options = expandOptions };
         var expandOutput = expandFormatter.Reformat(crunchOutput, 0);

--- a/WebFormatter/Shared/SettingsPanel.razor
+++ b/WebFormatter/Shared/SettingsPanel.razor
@@ -24,7 +24,6 @@
 <div><input type="number" class="number" @bind="State.Options.IndentSpaces" min="0">Indent Spaces</div>
 
 <div class="section-label">Miscellaneous</div>
-<div><input type="checkbox" @bind="State.Options.DontJustifyNumbers">Don't Justify Numbers</div>
 <div><input type="checkbox" @bind="AllowComments">Allow Comments</div>
 <div><input type="checkbox" @bind="State.Options.PreserveBlankLines">Preserve Blank Lines</div>
 <div><input type="checkbox" @bind="State.Options.AllowTrailingCommas">Allow Trailing Commas</div>

--- a/WebFormatter/Shared/SettingsPanel.razor
+++ b/WebFormatter/Shared/SettingsPanel.razor
@@ -1,37 +1,58 @@
 @using FracturedJson
+@using System.Data
 @inject WebFormatterState State
 
 <h2>Settings</h2>
 
-<div class="section-label">Length and Complexity</div>
-<div><input type="number" class="number" @bind="State.Options.MaxTotalLineLength" min="0" step="10">Max Total Line Length</div>
-<div><input type="number" class="number" @bind="State.Options.MaxInlineLength" min="0" step="10">Max Inline Length</div>
+<EditForm EditContext="@_editContext">
+    <div class="section-label">Length and Complexity</div>
+    <div><input type="number" class="number" @bind="State.Options.MaxTotalLineLength" min="0" step="10">Max Total Line Length</div>
+    <div><input type="number" class="number" @bind="State.Options.MaxInlineLength" min="0" step="10">Max Inline Length</div>
 
-<div><input type="number" class="number" @bind="State.Options.MaxInlineComplexity" min="-1">Max Inline Complexity</div>
-<div><input type="number" class="number" @bind="State.Options.MaxCompactArrayComplexity" min="-1">Max Compact Array Complexity</div>
-<div><input type="number" class="number" @bind="State.Options.MaxTableRowComplexity" min="-1">Max Table Row Complexity</div>
+    <div><input type="number" class="number" @bind="State.Options.MaxInlineComplexity" min="-1">Max Inline Complexity</div>
+    <div><input type="number" class="number" @bind="State.Options.MaxCompactArrayComplexity" min="-1">Max Compact Array Complexity</div>
+    <div><input type="number" class="number" @bind="State.Options.MaxTableRowComplexity" min="-1">Max Table Row Complexity</div>
 
-<div><input type="number" class="number" @bind="State.Options.MinCompactArrayRowItems" min="0">Min Compact Array Row Items</div>
-<div><input type="number" class="number" @bind="State.Options.AlwaysExpandDepth" min="-1">Always Expand Depth</div>
+    <div><input type="number" class="number" @bind="State.Options.MinCompactArrayRowItems" min="0">Min Compact Array Row Items</div>
+    <div><input type="number" class="number" @bind="State.Options.AlwaysExpandDepth" min="-1">Always Expand Depth</div>
 
-<div class="section-label">Padding</div>
-<div><input type="checkbox" @bind="State.Options.NestedBracketPadding">Nested Bracket Padding</div>
-<div><input type="checkbox" @bind="State.Options.SimpleBracketPadding">Simple Bracket Padding</div>
-<div><input type="checkbox" @bind="State.Options.ColonPadding">Colon Padding</div>
-<div><input type="checkbox" @bind="State.Options.CommaPadding">Comma Padding</div>
-<div><input type="checkbox" @bind="State.Options.CommentPadding">Comment Padding</div>
-<div><input type="checkbox" @bind="State.Options.UseTabToIndent">Use Tab To Indent</div>
-<div><input type="number" class="number" @bind="State.Options.IndentSpaces" min="0">Indent Spaces</div>
+    <div class="section-label">Padding</div>
+    <div><input type="checkbox" @bind="State.Options.NestedBracketPadding">Nested Bracket Padding</div>
+    <div><input type="checkbox" @bind="State.Options.SimpleBracketPadding">Simple Bracket Padding</div>
+    <div><input type="checkbox" @bind="State.Options.ColonPadding">Colon Padding</div>
+    <div><input type="checkbox" @bind="State.Options.CommaPadding">Comma Padding</div>
+    <div><input type="checkbox" @bind="State.Options.CommentPadding">Comment Padding</div>
+    <div><input type="checkbox" @bind="State.Options.UseTabToIndent">Use Tab To Indent</div>
+    <div><input type="number" class="number" @bind="State.Options.IndentSpaces" min="0">Indent Spaces</div>
 
-<div class="section-label">Miscellaneous</div>
-<div><input type="checkbox" @bind="AllowComments">Allow Comments</div>
-<div><input type="checkbox" @bind="State.Options.PreserveBlankLines">Preserve Blank Lines</div>
-<div><input type="checkbox" @bind="State.Options.AllowTrailingCommas">Allow Trailing Commas</div>
+    <div class="section-label">Miscellaneous</div>
+    <div>
+        <InputSelect @bind-Value="@State.Options.NumberListAlignment">
+            @foreach (var alignOpt in Enum.GetValues<NumberListAlignment>())
+            {
+                <option value="@alignOpt">@alignOpt</option>
+            }
+        </InputSelect>
+        <label>Number List Alignment</label>
+    </div>
+    <div><input type="checkbox" @bind="AllowComments">Allow Comments</div>
+    <div><input type="checkbox" @bind="State.Options.PreserveBlankLines">Preserve Blank Lines</div>
+    <div><input type="checkbox" @bind="State.Options.AllowTrailingCommas">Allow Trailing Commas</div>
 
-<button type="button" @onclick="State.SetToDefaults">Reset</button>
-&nbsp;<a href="https://github.com/j-brooke/FracturedJson/wiki/Options" target="_blank" rel="noopener">Settings Help</a>
+    <button type="button" @onclick="State.SetToDefaults">Reset</button>
+    &nbsp;<a href="https://github.com/j-brooke/FracturedJson/wiki/Options" target="_blank" rel="noopener">Settings Help</a>
+</EditForm>
+
 
 @code {
+    private EditContext? _editContext;
+
+    protected override void OnInitialized()
+    {
+        _editContext = new EditContext(State.Options);
+        base.OnInitialized();
+    }
+
     private bool AllowComments
     {
         get => GetAllowComments();


### PR DESCRIPTION
Removed option `DontJustifyNumbers` (boolean) and replaced it with `NumberListAlignment` (enum).  Below are examples of output:

```
LEFT
[
    {"a": 123.456 , "b": 0      , "c": 0   },
    {"a": 234567.8, "b": 0      , "c": 0   },
    {"a": 3       , "b": 0.00000, "c": 7e2 },
    {"a": null    , "b": 2e-1   , "c": 80e1},
    {"a": 5.6789  , "b": 3.5e-1 , "c": 0   }
]

RIGHT
[
    {"a":  123.456, "b":       0, "c":    0},
    {"a": 234567.8, "b":       0, "c":    0},
    {"a":        3, "b": 0.00000, "c":  7e2},
    {"a":     null, "b":    2e-1, "c": 80e1},
    {"a":   5.6789, "b":  3.5e-1, "c":    0}
]

DECIMAL
[
    {"a":    123.456 , "b": 0      , "c":  0  },
    {"a": 234567.8   , "b": 0      , "c":  0  },
    {"a":      3     , "b": 0.00000, "c":  7e2},
    {"a":   null     , "b": 2e-1   , "c": 80e1},
    {"a":      5.6789, "b": 3.5e-1 , "c":  0  }
]

NORMALIZE
[
    {"a":    123.4560, "b": 0.00, "c":   0},
    {"a": 234567.8000, "b": 0.00, "c":   0},
    {"a":      3.0000, "b": 0.00, "c": 700},
    {"a":   null     , "b": 0.20, "c": 800},
    {"a":      5.6789, "b": 0.35, "c":   0}
]
```
