### PR TITLE
Update System.Text.Json to 6.0.10

### DIFF
--- a/FracturedJson/FracturedJson.csproj
+++ b/FracturedJson/FracturedJson.csproj
@@ -32,6 +32,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Json" Version="6.0.6" />
+      <PackageReference Include="System.Text.Json" Version="6.0.10" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,

I have a project that has transitive references to System.Text.Json 6.0.6 via FracturedJson, which Visual Studio is highlighting as suffering from this new Microsoft CVE - https://github.com/advisories/GHSA-8g4q-xg66-9fp4

So I was just wondering if there was interest in updating the reference here to the fixed version?

Thanks.