### PR TITLE
Better table commas

### DIFF
--- a/FracturedJson/Formatter.cs
+++ b/FracturedJson/Formatter.cs
@@ -619,8 +619,9 @@ public class Formatter
             commaPos = (commaBeforePad) ? CommaPosition.BeforeValuePadding : CommaPosition.AfterValuePadding;
         }
 
-        // If this segment represents a whole row and this is the last element we won't have a comma.  But in some
-        // cases we need an equivalent space still, such as if the commas go before comments.
+        // If we're asked to include a comma, do it.  For internal segments, if we don't supply a comma, the padding
+        // will work out elsewhere.  But if this segment is the whole row of a table, we need to supply a dummy
+        // comma due to possible end-of-line comment complications.
         var commaType = (includeTrailingComma)
             ? _pads.Comma
             : (isWholeRow)

--- a/FracturedJson/Formatting/TableTemplate.cs
+++ b/FracturedJson/Formatting/TableTemplate.cs
@@ -42,6 +42,7 @@ internal class TableTemplate
     public int PrefixCommentLength { get; private set; }
     public int MiddleCommentLength { get; private set; }
     public int PostfixCommentLength { get; private set; }
+    public bool IsAnyPostCommentLineStyle { get; set; }
     public BracketPaddingType PadType { get; private set; } = BracketPaddingType.Simple;
 
     /// <summary>
@@ -241,6 +242,7 @@ internal class TableTemplate
         MiddleCommentLength = Math.Max(MiddleCommentLength, rowSegment.MiddleCommentLength);
         PrefixCommentLength = Math.Max(PrefixCommentLength, rowSegment.PrefixCommentLength);
         PostfixCommentLength = Math.Max(PostfixCommentLength, rowSegment.PostfixCommentLength);
+        IsAnyPostCommentLineStyle |= rowSegment.IsPostCommentLineStyle;
 
         if (rowSegment.Complexity >= 2)
             PadType = BracketPaddingType.Complex;

--- a/FracturedJson/Formatting/TableTemplate.cs
+++ b/FracturedJson/Formatting/TableTemplate.cs
@@ -120,7 +120,7 @@ internal class TableTemplate
     /// Added the number, properly aligned and possibly reformatted, according to our measurements.
     /// This assumes that the segment is a number list, and therefore that the item is a number or null.
     /// </summary>
-    public void FormatNumber(IBuffer buffer, JsonItem item)
+    public void FormatNumber(IBuffer buffer, JsonItem item, string commaBeforePadType)
     {
         var formatType = (_numberListAlignment is NumberListAlignment.Normalize && !AllowNumberNormalization)
             ? NumberListAlignment.Left
@@ -130,10 +130,10 @@ internal class TableTemplate
         switch (formatType)
         {
             case NumberListAlignment.Left:
-                buffer.Add(item.Value, _pads.Spaces(SimpleValueLength - item.ValueLength));
+                buffer.Add(item.Value, commaBeforePadType, _pads.Spaces(SimpleValueLength - item.ValueLength));
                 return;
             case NumberListAlignment.Right:
-                buffer.Add(_pads.Spaces(SimpleValueLength - item.ValueLength), item.Value);
+                buffer.Add(_pads.Spaces(SimpleValueLength - item.ValueLength), item.Value, commaBeforePadType);
                 return;
         }
 
@@ -143,7 +143,7 @@ internal class TableTemplate
             if (item.Type is JsonItemType.Null)
             {
                 buffer.Add(_pads.Spaces(_maxDigBeforeDecNorm - item.ValueLength), item.Value,
-                    _pads.Spaces(CompositeValueLength - _maxDigBeforeDecNorm));
+                    commaBeforePadType, _pads.Spaces(CompositeValueLength - _maxDigBeforeDecNorm));
                 return;
             }
 
@@ -152,7 +152,7 @@ internal class TableTemplate
 
             var parsedVal = double.Parse(item.Value, CultureInfo.InvariantCulture);
             var reformattedStr = string.Format(CultureInfo.InvariantCulture, _numberFormat, parsedVal);
-            buffer.Add(reformattedStr);
+            buffer.Add(reformattedStr, commaBeforePadType);
             return;
         }
 
@@ -160,7 +160,7 @@ internal class TableTemplate
         if (item.Type is JsonItemType.Null)
         {
             buffer.Add(_pads.Spaces(_maxDigBeforeDecRaw - item.ValueLength), item.Value,
-                _pads.Spaces(CompositeValueLength - _maxDigBeforeDecRaw));
+                commaBeforePadType, _pads.Spaces(CompositeValueLength - _maxDigBeforeDecRaw));
             return;
         }
 
@@ -178,7 +178,7 @@ internal class TableTemplate
             rightPad = CompositeValueLength - _maxDigBeforeDecRaw;
         }
 
-        buffer.Add(_pads.Spaces(leftPad), item.Value, _pads.Spaces(rightPad));
+        buffer.Add(_pads.Spaces(leftPad), item.Value, commaBeforePadType, _pads.Spaces(rightPad));
     }
 
     private static readonly char[] _dotOrE = new[] { '.', 'e', 'E' };

--- a/FracturedJson/FracturedJsonOptions.cs
+++ b/FracturedJson/FracturedJsonOptions.cs
@@ -50,8 +50,11 @@ public record FracturedJsonOptions
     /// </summary>
     public int MaxTableRowComplexity { get; set; } = 2;
 
-    // TODO: document
-    public TableCommaPlacement TableCommaPlacement { get; set; } = TableCommaPlacement.BeforePadding;
+    /// <summary>
+    /// Determines whether commas in table-formatted elements are lined up in their own column or right next to the
+    /// element that preceeds them.
+    /// </summary>
+    public TableCommaPlacement TableCommaPlacement { get; set; } = TableCommaPlacement.AfterPadding;
 
     /// <summary>
     /// Minimum number of items allowed per row to format an array as with multiple items per line across multiple

--- a/FracturedJson/FracturedJsonOptions.cs
+++ b/FracturedJson/FracturedJsonOptions.cs
@@ -50,6 +50,9 @@ public record FracturedJsonOptions
     /// </summary>
     public int MaxTableRowComplexity { get; set; } = 2;
 
+    // TODO: document
+    public TableCommaPlacement TableCommaPlacement { get; set; } = TableCommaPlacement.BeforePadding;
+
     /// <summary>
     /// Minimum number of items allowed per row to format an array as with multiple items per line across multiple
     /// lines.  This is an approximation, not a hard rule.  The idea is that if there will be too few items per row,

--- a/FracturedJson/TableCommaPlacement.cs
+++ b/FracturedJson/TableCommaPlacement.cs
@@ -1,0 +1,8 @@
+﻿namespace FracturedJson;
+
+public enum TableCommaPlacement
+{
+    BeforePadding,
+    AfterPadding,
+    BeforePaddingExceptNumbers,
+}

--- a/FracturedJson/TableCommaPlacement.cs
+++ b/FracturedJson/TableCommaPlacement.cs
@@ -1,8 +1,22 @@
 ﻿namespace FracturedJson;
 
+/// <summary>
+/// Specifies where commas should be in table-formatted elements.
+/// </summary>
 public enum TableCommaPlacement
 {
+    /// <summary>
+    /// Commas come right after the element that comes before them.
+    /// </summary>
     BeforePadding,
+
+    /// <summary>
+    /// Commas come after the column padding, all lined with each other.
+    /// </summary>
     AfterPadding,
+
+    /// <summary>
+    /// Commas come right after the element, except in the case of columns of numbers.
+    /// </summary>
     BeforePaddingExceptNumbers,
 }

--- a/FracturedJsonCli/Cli.cs
+++ b/FracturedJsonCli/Cli.cs
@@ -50,6 +50,16 @@ namespace FracturedJsonCli
                         }
                     },
                     {
+                        "k|comma=", "table comma placement [b,a,n]", s =>
+                            options.TableCommaPlacement = s.ToUpper() switch
+                            {
+                                "B" or "BEFORE" => TableCommaPlacement.BeforePadding,
+                                "A" or "AFTER" => TableCommaPlacement.AfterPadding,
+                                "N" or "NUMBER" => TableCommaPlacement.BeforePaddingExceptNumbers,
+                                _ => TableCommaPlacement.AfterPadding,
+                            }
+                    },
+                    {
                         "l|length=",
                         "maximum total line length when inlining",
                         (int n) => options.MaxTotalLineLength = n

--- a/FracturedJsonCli/FracturedJsonCli.csproj
+++ b/FracturedJsonCli/FracturedJsonCli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <AssemblyVersion>4.0.3</AssemblyVersion>
         <IsPackable>false</IsPackable>

--- a/Tests/EndingCommaFormattingTests.cs
+++ b/Tests/EndingCommaFormattingTests.cs
@@ -66,7 +66,7 @@ public class EndingCommaFormattingTests
         Assert.AreEqual(outputLines.Length, 6);
         StringAssert.Contains(output, "[1    ]");
 
-        // There should only be one comma - between the 1 and 2.
+        // There should only be one comma - between [1] and [false].
         var commaCount = output.Count(ch => ch == ',');
         Assert.AreEqual(1, commaCount);
     }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
+
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tests/UniversalJsonTests.cs
+++ b/Tests/UniversalJsonTests.cs
@@ -85,6 +85,21 @@ public class UniversalJsonTests
             IndentSpaces = 3,
             PrefixString = "\t\t"
         };
+        yield return new()
+        {
+            TableCommaPlacement = TableCommaPlacement.BeforePadding,
+            NumberListAlignment = NumberListAlignment.Left,
+        };
+        yield return new()
+        {
+            TableCommaPlacement = TableCommaPlacement.BeforePaddingExceptNumbers,
+            NumberListAlignment = NumberListAlignment.Decimal,
+        };
+        yield return new()
+        {
+            TableCommaPlacement = TableCommaPlacement.BeforePaddingExceptNumbers,
+            NumberListAlignment = NumberListAlignment.Normalize,
+        };
     }
 
     private static string EolString(FracturedJsonOptions options)


### PR DESCRIPTION
Introduced new setting, `TableCommaPlacement`.  If set to `BeforePadding`, table commas will be placed immediately next to the values they follow, instead of after padding.